### PR TITLE
Multiple node attribute query bug

### DIFF
--- a/plattar-web/elements/base/base-element.js
+++ b/plattar-web/elements/base/base-element.js
@@ -120,7 +120,7 @@ class BaseElement extends HTMLElement {
         let first = true;
 
         for (const [key, value] of attr.entries()) {
-            queryStr = first ? ("?" + key + "=" + value) : ("&" + key + "=" + value);
+            queryStr += (first ? ("?" + key + "=" + value) : ("&" + key + "=" + value));
 
             first = false;
         }


### PR DESCRIPTION
- See Issue #1
- The Query String was not appending correctly, resulting in incorrect final url string when multiple attributes were used