### PR TITLE
Add UI attribute support to Configurator Node

### DIFF
--- a/plattar-web/elements/base/base-element.js
+++ b/plattar-web/elements/base/base-element.js
@@ -1,3 +1,4 @@
+const Util = require("../../util/util");
 const ElementController = require("../controllers/element-controller");
 
 class BaseElement extends HTMLElement {
@@ -130,6 +131,10 @@ class BaseElement extends HTMLElement {
 
     get elementType() {
         return "none";
+    }
+
+    get elementLocation() {
+        return Util.getElementLocation(this.elementType);
     }
 }
 

--- a/plattar-web/elements/configurator-element.js
+++ b/plattar-web/elements/configurator-element.js
@@ -13,6 +13,16 @@ class ConfiguratorElement extends BaseElement {
         return "configurator";
     }
 
+    get elementLocation() {
+        if (this.hasAttribute("show-ui")) {
+            const state = this.getAttribute("show-ui");
+
+            return state === "true" ? "configurator/dist/index.html" : super.elementLocation;
+        }
+
+        return super.elementLocation;
+    }
+
     get optionalAttributes() {
         return [{
             key: "config-state",

--- a/plattar-web/elements/controllers/element-controller.js
+++ b/plattar-web/elements/controllers/element-controller.js
@@ -42,7 +42,7 @@ class ElementController {
             throw new Error("ElementController - attribute \"server\" must be one of \"production\", \"staging\" or \"dev\"");
         }
 
-        const embedLocation = Util.getElementLocation(element.elementType);
+        const embedLocation = element.elementLocation;
 
         if (embedLocation === undefined) {
             throw new Error("ElementController - element named \"" + elementType + "\" is invalid");

--- a/plattar-web/elements/controllers/iframe-controller.js
+++ b/plattar-web/elements/controllers/iframe-controller.js
@@ -35,15 +35,7 @@ class IFrameController {
         if (element.hasAttribute("fullscreen")) {
             const style = document.createElement('style');
 
-            style.textContent = `
-                ._PlattarFullScreen {
-                    width: 100%;
-                    height: 100%;
-                    position: absolute;
-                    top: 0;
-                    left: 0;
-                }
-            `;
+            style.textContent = `._PlattarFullScreen { width: 100%; height: 100%; position: absolute; top: 0; left: 0; }`;
 
             this._iframe.className = "_PlattarFullScreen";
 

--- a/plattar-web/package.json
+++ b/plattar-web/package.json
@@ -42,10 +42,10 @@
     "@plattar/context-messenger": "^1.113.6"
   },
   "devDependencies": {
-    "@babel/cli": "^7.17.6",
-    "@babel/core": "^7.17.9",
-    "@babel/preset-env": "^7.16.11",
+    "@babel/cli": "^7.17.10",
+    "@babel/core": "^7.17.10",
+    "@babel/preset-env": "^7.17.10",
     "browserify": "^17.0.0",
-    "uglify-js": "^3.15.4"
+    "uglify-js": "^3.15.5"
   }
 }

--- a/plattar-web/util/util.js
+++ b/plattar-web/util/util.js
@@ -1,9 +1,9 @@
 class Util {
     static getServerLocation(server) {
         switch (server) {
-            case "production": return "https://app.plattar.com/renderer/";
-            case "staging": return "https://staging.plattar.space/renderer/";
-            case "dev": return "https://localhost/renderer/";
+            case "production": return "https://app.plattar.com/";
+            case "staging": return "https://staging.plattar.space/";
+            case "dev": return "https://localhost/";
             default: return undefined;
         }
     }
@@ -12,25 +12,7 @@ class Util {
         const isValid = Util.isValidType(etype);
 
         if (isValid) {
-            return etype + ".html";
-        }
-
-        return undefined;
-    }
-
-    static getElementBundleLocation(etype, server) {
-        const location = Util.getServerLocation(server);
-
-        if (!location) {
-            return undefined;
-        }
-
-        const isValid = Util.isValidType(etype);
-
-        if (isValid) {
-            const isMinified = location === "dev" ? false : true;
-
-            return isMinified ? (etype + "-bundle.min.js") : (etype + "-bundle.js");
+            return "renderer/" + etype + ".html";
         }
 
         return undefined;


### PR DESCRIPTION
- See Issue #9
- Element Location is now computed in BaseElement for flexibility and consistency
- Added support for "show-ui" attribute to launch Configurator with UI
- Removed unused Util.getElementBundleLocation() function