### PR TITLE
Allow Messenger parent access

### DIFF
--- a/plattar-web/elements/base/base-element.js
+++ b/plattar-web/elements/base/base-element.js
@@ -27,6 +27,10 @@ class BaseElement extends HTMLElement {
         return this._controller ? this._controller.context : undefined;
     }
 
+    get parent() {
+        return this._controller ? this._controller.parent : undefined;
+    }
+
     get element() {
         return this._controller;
     }

--- a/plattar-web/elements/controllers/element-controller.js
+++ b/plattar-web/elements/controllers/element-controller.js
@@ -84,6 +84,10 @@ class ElementController {
         return messenger.self;
     }
 
+    get parent() {
+        return messenger.parent;
+    }
+
     get controller() {
         return this._controller;
     }


### PR DESCRIPTION
- Added messenger.parent access to be able to access the parent frame of the messenger
- This is required for certain functionalities for multi-tiered SDK setups (such as Configurator with UI)